### PR TITLE
remote static from function declaration in source

### DIFF
--- a/src/fmt.c
+++ b/src/fmt.c
@@ -156,7 +156,7 @@ void gamma_inc_like(double *f, double t, FINT m)
         }
 }
 
-static void qgamma_inc_like(long double *f, long double t, FINT m)
+void qgamma_inc_like(long double *f, long double t, FINT m)
 {
         FINT i;
         if (t < m + 1.5) {


### PR DESCRIPTION
static on functions means the symbols are not visible in any other
compilation unit.  this means they can be used in headers but not source
files (unless you include source files in other source files, which is a
bad practice).

see http://stackoverflow.com/questions/558122/what-is-a-static-function
for details.

there is a conflicting semantic between GCC's behavior and ISO C99 and
later, such that this code may work with GCC or C89 mode, but is likely
to break once compilers that default to C11 (e.g. recent GCC and Clang)
are used.