### PR TITLE
bugfix: use fabsl with long double (not fabs)

### DIFF
--- a/src/rys_roots.c
+++ b/src/rys_roots.c
@@ -1667,7 +1667,7 @@ L30:
         dr = .0625l * dr;
         r5 = r - dr;
         r6 = r + dr;
-        if (fabs(delta) < accrt || r5 == r || r6 == r) {
+        if (fabsl(delta) < accrt || r5 == r || r6 == r) {
             goto L90;
         }
         ++icount;


### PR DESCRIPTION
```
src/rys_roots.c:1670:13: warning: absolute value function 'fabs' given an argument of
      type 'long double' but has parameter of type 'double' which may cause truncation of value [-Wabsolute-value]
        if (fabs(delta) < accrt || r5 == r || r6 == r) {
            ^
src/rys_roots.c:1670:13: note: use function 'fabsl' instead
        if (fabs(delta) < accrt || r5 == r || r6 == r) {
            ^~~~
            fabsl
```