### PR TITLE
Make tests use Python 3 style print function.

### DIFF
--- a/testsuite/test_3c2e.py
+++ b/testsuite/test_3c2e.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # $Id$
 # -*- coding: utf-8
+from __future__ import print_function
 
 '''
 test libcint
@@ -194,13 +195,13 @@ def test_int3c2e_sph(name, fnref, vref, dim, place):
                 intoref(pref, shls, c_atm, natm, c_bas, nbas, c_env, opt)
                 intor(pop, shls, c_atm, natm, c_bas, nbas, c_env, opt)
                 if not numpy.allclose(opref[:nd], op[:nd]):
-                    print 'Fail:', name, i,j,k
+                    print('Fail:', name, i,j,k)
                 v1 += abs(numpy.array(op[:nd])).sum()
                 cnt += nd
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 
 def sf2spinor(mat, i, j, bas):
@@ -255,13 +256,13 @@ def test_int3c2e_spinor(name, fnref, vref, dim, place):
                 intor(op.ctypes.data_as(ctypes.c_void_p), shls,
                       c_atm, natm, c_bas, nbas, c_env, opt)
                 if not numpy.allclose(zmat, op[:,:,:,0]):
-                    print 'Fail:', name, i,j,k
+                    print('Fail:', name, i,j,k)
                 v1 += abs(numpy.array(op)).sum()
                 cnt += op.size
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 
 def test_int2c_sph(name, fnref, vref, dim, place):
@@ -286,13 +287,13 @@ def test_int2c_sph(name, fnref, vref, dim, place):
             shls = (ctypes.c_int * 2)(i, k)
             intor(pop, shls, c_atm, natm, c_bas, nbas, c_env, opt)
             if not numpy.allclose(opref[:nd], op[:nd]):
-                print 'Fail:', name, i,k
+                print('Fail:', name, i,k)
             v1 += abs(numpy.array(op[:nd])).sum()
             cnt += nd
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 
 

--- a/testsuite/test_cint.py
+++ b/testsuite/test_cint.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # $Id$
 # -*- coding: utf-8
+from __future__ import print_function
 
 '''
 test libcint
@@ -160,9 +161,9 @@ def test_int1e_sph(name, vref, dim, place):
             v1 += abs(numpy.array(op[:di*dj*dim])).sum()
             cnt += di*dj*dim
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 def cdouble_to_cmplx(arr):
     return numpy.array(arr)[0::2] + numpy.array(arr)[1::2] * 1j
@@ -182,9 +183,9 @@ def test_int1e_spinor(name, vref, dim, place):
             v1 += abs(cdouble_to_cmplx(op[:di*dj*dim*2])).sum()
             cnt += di*dj*dim*2
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 def max_loc(arr):
     loc = []
@@ -222,11 +223,11 @@ def test_comp1e_spinor(name1, name_ref, shift, dim, place):
                      - cdouble_to_cmplx(op_ref[:di*dj*dim*2]).reshape(di,dj,dim))
             if numpy.round(dd, place).sum():
                 maxi = dd.argmax()
-                print "* FAIL: ", name1, "/", name_ref, ". shell:", i, j, \
+                print("* FAIL: ", name1, "/", name_ref, ". shell:", i, j, \
                         "err:", dd.flatten()[maxi], \
-                        "/", op_ref[maxi*2]+op_ref[maxi*2+1]*1j
+                        "/", op_ref[maxi*2]+op_ref[maxi*2+1]*1j)
                 return
-    print "pass: ", name1, "/", name_ref
+    print("pass: ", name1, "/", name_ref)
 
 ####################
 def test_int2e_sph(name, vref, dim, place):
@@ -248,9 +249,9 @@ def test_int2e_sph(name, vref, dim, place):
                     v1 += abs(numpy.array(op[:di*dj*dk*dl*dim])).sum()
                     cnt += di*dj*dk*dl*dim
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 def test_int2e_spinor(name, vref, dim, place):
     intor = getattr(_cint, name)
@@ -271,9 +272,9 @@ def test_int2e_spinor(name, vref, dim, place):
                     v1 += abs(cdouble_to_cmplx(op[:di*dj*dk*dl*dim*2])).sum()
                     cnt += di*dj*dk*dl*dim*2
     if close(v1, vref, cnt, place):
-        print "pass: ", name
+        print("pass: ", name)
     else:
-        print "* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref
+        print("* FAIL: ", name, ". err:", '%.16g' % abs(v1-vref), "/", vref)
 
 def test_comp2e_spinor(name1, name_ref, shift, dim, place):
     intor     = getattr(_cint, name1)
@@ -309,11 +310,11 @@ def test_comp2e_spinor(name1, name_ref, shift, dim, place):
                              - cdouble_to_cmplx(op_ref[:di*dj*dk*dl*dim*2]).reshape(di,dj,dk,dl,dim))
                     if numpy.round(dd, place).sum():
                         maxi = dd.argmax()
-                        print "* FAIL: ", name1, "/", name_ref, ". shell:", i, j, k, l, \
+                        print("* FAIL: ", name1, "/", name_ref, ". shell:", i, j, k, l, \
                                 "err:", dd.flatten()[maxi], \
-                                "/", op_ref[maxi*2]+op_ref[maxi*2+1]*1j
+                                "/", op_ref[maxi*2]+op_ref[maxi*2+1]*1j)
                         return
-    print "pass: ", name1, "/", name_ref
+    print("pass: ", name1, "/", name_ref)
 
 
 
@@ -442,4 +443,4 @@ if __name__ == "__main__":
             v1 += abs(opzz-oprr[:,:,8]).sum()
             v1 += abs(opr2-oprr[:,:,0]-oprr[:,:,4]-oprr[:,:,8]).sum()
             if round(v1/(di*dj), 13):
-                print "* FAIL: ", i, j, v1
+                print("* FAIL: ", i, j, v1)


### PR DESCRIPTION
Currently the tests fail with Python 3, which is a problem since Python 2 has been deprecated.