### PR TITLE
Add two integral types for CNEO-DFT Hessian

### DIFF
--- a/scripts/auto_intor.cl
+++ b/scripts/auto_intor.cl
@@ -174,6 +174,8 @@
   '("int1e_ipnucip"             ( nabla \| nuc \| nabla ))
   '("int1e_ipiprinv"            ( nabla nabla \| rinv \| ))
   '("int1e_iprinvip"            ( nabla \| rinv \| nabla ))
+  '("int1e_ipipr"               ( nabla nabla \| rc \| ))
+  '("int1e_iprip"               ( nabla \| rc \| nabla ))
   '("int2e_ipip1"               ( nabla nabla \, \| \, ))
   '("int2e_ipvip1"              ( nabla \, nabla \| \, ))
   '("int2e_ip1ip2"              ( nabla \, \| nabla \, ))

--- a/src/autocode/hess.c
+++ b/src/autocode/hess.c
@@ -836,6 +836,290 @@ return CINT1e_spinor_drv(out, dims, &envs, cache, &c2s_sf_1e, 1);
 } // int1e_iprinvip_spinor
 ALL_CINT1E(int1e_iprinvip)
 ALL_CINT1E_FORTRAN_(int1e_iprinvip)
+/* <NABLA NABLA i|RC |j> */
+void CINTgout1e_int1e_ipipr(double *gout, double *g, FINT *idx, CINTEnvVars *envs, FINT gout_empty) {
+FINT nf = envs->nf;
+FINT ix, iy, iz, n;
+double *g0 = g;
+double *g1 = g0 + envs->g_size * 3;
+double *g2 = g1 + envs->g_size * 3;
+double *g3 = g2 + envs->g_size * 3;
+double *g4 = g3 + envs->g_size * 3;
+double *g5 = g4 + envs->g_size * 3;
+double *g6 = g5 + envs->g_size * 3;
+double *g7 = g6 + envs->g_size * 3;
+double drj[3];
+drj[0] = envs->rj[0] - envs->env[PTR_COMMON_ORIG+0];
+drj[1] = envs->rj[1] - envs->env[PTR_COMMON_ORIG+1];
+drj[2] = envs->rj[2] - envs->env[PTR_COMMON_ORIG+2];
+double s[27];
+G1E_RCJ(g1, g0, envs->i_l+2, envs->j_l+0, 0);
+G1E_D_I(g2, g0, envs->i_l+1, envs->j_l, 0);
+G1E_D_I(g3, g1, envs->i_l+1, envs->j_l, 0);
+G1E_D_I(g4, g0, envs->i_l+0, envs->j_l, 0);
+G1E_D_I(g5, g1, envs->i_l+0, envs->j_l, 0);
+G1E_D_I(g6, g2, envs->i_l+0, envs->j_l, 0);
+G1E_D_I(g7, g3, envs->i_l+0, envs->j_l, 0);
+for (n = 0; n < nf; n++) {
+ix = idx[0+n*3];
+iy = idx[1+n*3];
+iz = idx[2+n*3];
+s[0] = + g7[ix+0]*g0[iy+0]*g0[iz+0];
+s[1] = + g6[ix+0]*g1[iy+0]*g0[iz+0];
+s[2] = + g6[ix+0]*g0[iy+0]*g1[iz+0];
+s[3] = + g5[ix+0]*g2[iy+0]*g0[iz+0];
+s[4] = + g4[ix+0]*g3[iy+0]*g0[iz+0];
+s[5] = + g4[ix+0]*g2[iy+0]*g1[iz+0];
+s[6] = + g5[ix+0]*g0[iy+0]*g2[iz+0];
+s[7] = + g4[ix+0]*g1[iy+0]*g2[iz+0];
+s[8] = + g4[ix+0]*g0[iy+0]*g3[iz+0];
+s[9] = + g3[ix+0]*g4[iy+0]*g0[iz+0];
+s[10] = + g2[ix+0]*g5[iy+0]*g0[iz+0];
+s[11] = + g2[ix+0]*g4[iy+0]*g1[iz+0];
+s[12] = + g1[ix+0]*g6[iy+0]*g0[iz+0];
+s[13] = + g0[ix+0]*g7[iy+0]*g0[iz+0];
+s[14] = + g0[ix+0]*g6[iy+0]*g1[iz+0];
+s[15] = + g1[ix+0]*g4[iy+0]*g2[iz+0];
+s[16] = + g0[ix+0]*g5[iy+0]*g2[iz+0];
+s[17] = + g0[ix+0]*g4[iy+0]*g3[iz+0];
+s[18] = + g3[ix+0]*g0[iy+0]*g4[iz+0];
+s[19] = + g2[ix+0]*g1[iy+0]*g4[iz+0];
+s[20] = + g2[ix+0]*g0[iy+0]*g5[iz+0];
+s[21] = + g1[ix+0]*g2[iy+0]*g4[iz+0];
+s[22] = + g0[ix+0]*g3[iy+0]*g4[iz+0];
+s[23] = + g0[ix+0]*g2[iy+0]*g5[iz+0];
+s[24] = + g1[ix+0]*g0[iy+0]*g6[iz+0];
+s[25] = + g0[ix+0]*g1[iy+0]*g6[iz+0];
+s[26] = + g0[ix+0]*g0[iy+0]*g7[iz+0];
+if (gout_empty) {
+gout[n*27+0] = + s[0];
+gout[n*27+1] = + s[1];
+gout[n*27+2] = + s[2];
+gout[n*27+3] = + s[9];
+gout[n*27+4] = + s[10];
+gout[n*27+5] = + s[11];
+gout[n*27+6] = + s[18];
+gout[n*27+7] = + s[19];
+gout[n*27+8] = + s[20];
+gout[n*27+9] = + s[3];
+gout[n*27+10] = + s[4];
+gout[n*27+11] = + s[5];
+gout[n*27+12] = + s[12];
+gout[n*27+13] = + s[13];
+gout[n*27+14] = + s[14];
+gout[n*27+15] = + s[21];
+gout[n*27+16] = + s[22];
+gout[n*27+17] = + s[23];
+gout[n*27+18] = + s[6];
+gout[n*27+19] = + s[7];
+gout[n*27+20] = + s[8];
+gout[n*27+21] = + s[15];
+gout[n*27+22] = + s[16];
+gout[n*27+23] = + s[17];
+gout[n*27+24] = + s[24];
+gout[n*27+25] = + s[25];
+gout[n*27+26] = + s[26];
+} else {
+gout[n*27+0] += + s[0];
+gout[n*27+1] += + s[1];
+gout[n*27+2] += + s[2];
+gout[n*27+3] += + s[9];
+gout[n*27+4] += + s[10];
+gout[n*27+5] += + s[11];
+gout[n*27+6] += + s[18];
+gout[n*27+7] += + s[19];
+gout[n*27+8] += + s[20];
+gout[n*27+9] += + s[3];
+gout[n*27+10] += + s[4];
+gout[n*27+11] += + s[5];
+gout[n*27+12] += + s[12];
+gout[n*27+13] += + s[13];
+gout[n*27+14] += + s[14];
+gout[n*27+15] += + s[21];
+gout[n*27+16] += + s[22];
+gout[n*27+17] += + s[23];
+gout[n*27+18] += + s[6];
+gout[n*27+19] += + s[7];
+gout[n*27+20] += + s[8];
+gout[n*27+21] += + s[15];
+gout[n*27+22] += + s[16];
+gout[n*27+23] += + s[17];
+gout[n*27+24] += + s[24];
+gout[n*27+25] += + s[25];
+gout[n*27+26] += + s[26];
+}}}
+void int1e_ipipr_optimizer(CINTOpt **opt, FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env) {
+FINT ng[] = {2, 1, 0, 0, 3, 1, 1, 27};
+CINTall_1e_optimizer(opt, ng, atm, natm, bas, nbas, env);
+}
+CACHE_SIZE_T int1e_ipipr_cart(double *out, FINT *dims, FINT *shls,
+FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env, CINTOpt *opt, double *cache) {
+FINT ng[] = {2, 1, 0, 0, 3, 1, 1, 27};
+CINTEnvVars envs;
+CINTinit_int1e_EnvVars(&envs, ng, shls, atm, natm, bas, nbas, env);
+envs.f_gout = &CINTgout1e_int1e_ipipr;
+return CINT1e_drv(out, dims, &envs, cache, &c2s_cart_1e, 0);
+} // int1e_ipipr_cart
+CACHE_SIZE_T int1e_ipipr_sph(double *out, FINT *dims, FINT *shls,
+FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env, CINTOpt *opt, double *cache) {
+FINT ng[] = {2, 1, 0, 0, 3, 1, 1, 27};
+CINTEnvVars envs;
+CINTinit_int1e_EnvVars(&envs, ng, shls, atm, natm, bas, nbas, env);
+envs.f_gout = &CINTgout1e_int1e_ipipr;
+return CINT1e_drv(out, dims, &envs, cache, &c2s_sph_1e, 0);
+} // int1e_ipipr_sph
+CACHE_SIZE_T int1e_ipipr_spinor(double complex *out, FINT *dims, FINT *shls,
+FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env, CINTOpt *opt, double *cache) {
+FINT ng[] = {2, 1, 0, 0, 3, 1, 1, 27};
+CINTEnvVars envs;
+CINTinit_int1e_EnvVars(&envs, ng, shls, atm, natm, bas, nbas, env);
+envs.f_gout = &CINTgout1e_int1e_ipipr;
+return CINT1e_spinor_drv(out, dims, &envs, cache, &c2s_sf_1e, 0);
+} // int1e_ipipr_spinor
+ALL_CINT1E(int1e_ipipr)
+ALL_CINT1E_FORTRAN_(int1e_ipipr)
+/* <NABLA i|RC |NABLA j> */
+void CINTgout1e_int1e_iprip(double *gout, double *g, FINT *idx, CINTEnvVars *envs, FINT gout_empty) {
+FINT nf = envs->nf;
+FINT ix, iy, iz, n;
+double *g0 = g;
+double *g1 = g0 + envs->g_size * 3;
+double *g2 = g1 + envs->g_size * 3;
+double *g3 = g2 + envs->g_size * 3;
+double *g4 = g3 + envs->g_size * 3;
+double *g5 = g4 + envs->g_size * 3;
+double *g6 = g5 + envs->g_size * 3;
+double *g7 = g6 + envs->g_size * 3;
+double drj[3];
+drj[0] = envs->rj[0] - envs->env[PTR_COMMON_ORIG+0];
+drj[1] = envs->rj[1] - envs->env[PTR_COMMON_ORIG+1];
+drj[2] = envs->rj[2] - envs->env[PTR_COMMON_ORIG+2];
+double s[27];
+G1E_D_J(g1, g0, envs->i_l+1, envs->j_l+0, 0);
+G1E_RCJ(g2, g0, envs->i_l+1, envs->j_l+1, 0);
+G1E_D_J(g3, g2, envs->i_l+1, envs->j_l+0, 0);
+G1E_D_I(g4, g0, envs->i_l+0, envs->j_l, 0);
+G1E_D_I(g5, g1, envs->i_l+0, envs->j_l, 0);
+G1E_D_I(g6, g2, envs->i_l+0, envs->j_l, 0);
+G1E_D_I(g7, g3, envs->i_l+0, envs->j_l, 0);
+for (n = 0; n < nf; n++) {
+ix = idx[0+n*3];
+iy = idx[1+n*3];
+iz = idx[2+n*3];
+s[0] = + g7[ix+0]*g0[iy+0]*g0[iz+0];
+s[1] = + g6[ix+0]*g1[iy+0]*g0[iz+0];
+s[2] = + g6[ix+0]*g0[iy+0]*g1[iz+0];
+s[3] = + g5[ix+0]*g2[iy+0]*g0[iz+0];
+s[4] = + g4[ix+0]*g3[iy+0]*g0[iz+0];
+s[5] = + g4[ix+0]*g2[iy+0]*g1[iz+0];
+s[6] = + g5[ix+0]*g0[iy+0]*g2[iz+0];
+s[7] = + g4[ix+0]*g1[iy+0]*g2[iz+0];
+s[8] = + g4[ix+0]*g0[iy+0]*g3[iz+0];
+s[9] = + g3[ix+0]*g4[iy+0]*g0[iz+0];
+s[10] = + g2[ix+0]*g5[iy+0]*g0[iz+0];
+s[11] = + g2[ix+0]*g4[iy+0]*g1[iz+0];
+s[12] = + g1[ix+0]*g6[iy+0]*g0[iz+0];
+s[13] = + g0[ix+0]*g7[iy+0]*g0[iz+0];
+s[14] = + g0[ix+0]*g6[iy+0]*g1[iz+0];
+s[15] = + g1[ix+0]*g4[iy+0]*g2[iz+0];
+s[16] = + g0[ix+0]*g5[iy+0]*g2[iz+0];
+s[17] = + g0[ix+0]*g4[iy+0]*g3[iz+0];
+s[18] = + g3[ix+0]*g0[iy+0]*g4[iz+0];
+s[19] = + g2[ix+0]*g1[iy+0]*g4[iz+0];
+s[20] = + g2[ix+0]*g0[iy+0]*g5[iz+0];
+s[21] = + g1[ix+0]*g2[iy+0]*g4[iz+0];
+s[22] = + g0[ix+0]*g3[iy+0]*g4[iz+0];
+s[23] = + g0[ix+0]*g2[iy+0]*g5[iz+0];
+s[24] = + g1[ix+0]*g0[iy+0]*g6[iz+0];
+s[25] = + g0[ix+0]*g1[iy+0]*g6[iz+0];
+s[26] = + g0[ix+0]*g0[iy+0]*g7[iz+0];
+if (gout_empty) {
+gout[n*27+0] = + s[0];
+gout[n*27+1] = + s[1];
+gout[n*27+2] = + s[2];
+gout[n*27+3] = + s[3];
+gout[n*27+4] = + s[4];
+gout[n*27+5] = + s[5];
+gout[n*27+6] = + s[6];
+gout[n*27+7] = + s[7];
+gout[n*27+8] = + s[8];
+gout[n*27+9] = + s[9];
+gout[n*27+10] = + s[10];
+gout[n*27+11] = + s[11];
+gout[n*27+12] = + s[12];
+gout[n*27+13] = + s[13];
+gout[n*27+14] = + s[14];
+gout[n*27+15] = + s[15];
+gout[n*27+16] = + s[16];
+gout[n*27+17] = + s[17];
+gout[n*27+18] = + s[18];
+gout[n*27+19] = + s[19];
+gout[n*27+20] = + s[20];
+gout[n*27+21] = + s[21];
+gout[n*27+22] = + s[22];
+gout[n*27+23] = + s[23];
+gout[n*27+24] = + s[24];
+gout[n*27+25] = + s[25];
+gout[n*27+26] = + s[26];
+} else {
+gout[n*27+0] += + s[0];
+gout[n*27+1] += + s[1];
+gout[n*27+2] += + s[2];
+gout[n*27+3] += + s[3];
+gout[n*27+4] += + s[4];
+gout[n*27+5] += + s[5];
+gout[n*27+6] += + s[6];
+gout[n*27+7] += + s[7];
+gout[n*27+8] += + s[8];
+gout[n*27+9] += + s[9];
+gout[n*27+10] += + s[10];
+gout[n*27+11] += + s[11];
+gout[n*27+12] += + s[12];
+gout[n*27+13] += + s[13];
+gout[n*27+14] += + s[14];
+gout[n*27+15] += + s[15];
+gout[n*27+16] += + s[16];
+gout[n*27+17] += + s[17];
+gout[n*27+18] += + s[18];
+gout[n*27+19] += + s[19];
+gout[n*27+20] += + s[20];
+gout[n*27+21] += + s[21];
+gout[n*27+22] += + s[22];
+gout[n*27+23] += + s[23];
+gout[n*27+24] += + s[24];
+gout[n*27+25] += + s[25];
+gout[n*27+26] += + s[26];
+}}}
+void int1e_iprip_optimizer(CINTOpt **opt, FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env) {
+FINT ng[] = {1, 2, 0, 0, 3, 1, 1, 27};
+CINTall_1e_optimizer(opt, ng, atm, natm, bas, nbas, env);
+}
+CACHE_SIZE_T int1e_iprip_cart(double *out, FINT *dims, FINT *shls,
+FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env, CINTOpt *opt, double *cache) {
+FINT ng[] = {1, 2, 0, 0, 3, 1, 1, 27};
+CINTEnvVars envs;
+CINTinit_int1e_EnvVars(&envs, ng, shls, atm, natm, bas, nbas, env);
+envs.f_gout = &CINTgout1e_int1e_iprip;
+return CINT1e_drv(out, dims, &envs, cache, &c2s_cart_1e, 0);
+} // int1e_iprip_cart
+CACHE_SIZE_T int1e_iprip_sph(double *out, FINT *dims, FINT *shls,
+FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env, CINTOpt *opt, double *cache) {
+FINT ng[] = {1, 2, 0, 0, 3, 1, 1, 27};
+CINTEnvVars envs;
+CINTinit_int1e_EnvVars(&envs, ng, shls, atm, natm, bas, nbas, env);
+envs.f_gout = &CINTgout1e_int1e_iprip;
+return CINT1e_drv(out, dims, &envs, cache, &c2s_sph_1e, 0);
+} // int1e_iprip_sph
+CACHE_SIZE_T int1e_iprip_spinor(double complex *out, FINT *dims, FINT *shls,
+FINT *atm, FINT natm, FINT *bas, FINT nbas, double *env, CINTOpt *opt, double *cache) {
+FINT ng[] = {1, 2, 0, 0, 3, 1, 1, 27};
+CINTEnvVars envs;
+CINTinit_int1e_EnvVars(&envs, ng, shls, atm, natm, bas, nbas, env);
+envs.f_gout = &CINTgout1e_int1e_iprip;
+return CINT1e_spinor_drv(out, dims, &envs, cache, &c2s_sf_1e, 0);
+} // int1e_iprip_spinor
+ALL_CINT1E(int1e_iprip)
+ALL_CINT1E_FORTRAN_(int1e_iprip)
 /* <k NABLA NABLA i|R12 |j l> : i,j \in electron 1; k,l \in electron 2
  * = (NABLA NABLA i j|R12 |k l) */
 void CINTgout2e_int2e_ipip1(double *gout,


### PR DESCRIPTION
Hessian of constrained nuclear-electronic orbital density functional
theory requires second order derivatives of rc matrices. Add these two
integral types to make the Hessian implementation possible in PySCF.

Ref:
J. Chem. Phys. 154, 244110 (2021); doi: 10.1063/5.0055506