### PR TITLE
README: Clarified the base of the logarithm for env[PTR_EXPCUTOFF].

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ Known problems
     Schwarz inequality to estimate upper limit of an integral, the default
     integral cutoff might not be accurate enough. It can be adjusted by the
     parameter ``env[PTR_EXPCUTOFF]`` (since libcint 4.0). This parameter needs to be
-    set to ``abs(log(cutoff_threshold))``.
+    set to ``abs(ln(cutoff_threshold))``.
 
 * On 64-bit systems, ``make test`` stop with error: ::
 


### PR DESCRIPTION
After reading [this issue](https://github.com/sunqm/libcint/issues/56#issuecomment-827144466), I noticed the user never replied after being given the following line:
```
env[PTR_EXPCUTOFF] = 34.54  # abs(log(1e-15))
```
Without specifying the base of that logarithm, a lot of people would assume it's base ten, especially quantum chemists since setting the integral cutoff threshold at 1e-15 [in MRCC would be](https://www.mrcc.hu/MRCC/manual/html/multiple/S12.xhtml) done by `itol=15`, and [in CFOUR would be](https://cfour.uni-mainz.de/cfour/index.php?n=Main.ListOfKeywordsInAlphabeticalOrder) `XFORM_TOL=15` (these are just two examples).

Google's default calculator uses a base 10 logarithm:

![image](https://user-images.githubusercontent.com/1163013/211124473-e89c67eb-0b1b-4c4d-856d-1dbc287d1707.png)

In computer science, the base is often assumed to be 2.

In this case, the correct solution will always be obtained (with no confusion) if we use `ln` for the base `e` logarithm:

![image](https://user-images.githubusercontent.com/1163013/211124789-20bcfa02-19f7-4469-a500-210c2b8bd326.png)

This pull request makes this more clear in the README file, which is the first and only thing seen by many users who don't dig deeply into the code or previous GitHub issues.
