### PR TITLE
Fixed undefined identifier

### DIFF
--- a/src/optimizer.c
+++ b/src/optimizer.c
@@ -332,11 +332,11 @@ FINT CINTset_pairdata(PairData *pairdata, double *ai, double *aj, double *ri, do
         //    <~ (d+1/sqrt(aij))^(li+lj) * (pi/aij)^1.5
         aij = ai[iprim-1] + aj[jprim-1];
         double log_rr_ij = 1.7 - 1.5 * approx_log(aij);
+        double dist_ij = sqrt(rr_ij);
         int lij = li_ceil + lj_ceil;
         if (lij > 0) {
 #ifdef WITH_RANGE_COULOMB
                 double omega = env[PTR_RANGE_OMEGA];
-                double dist_ij = sqrt(rr_ij);
                 if (omega < 0) {
                         double r_guess = 8.;
                         double omega2 = omega * omega;


### PR DESCRIPTION
Hi, thanks for this library. My installation failed because dist_ij was undefined in the `#else`-block in line 349, so I moved the definition further up and it works. 

I tested this now with icc 2021.2.0 and with gcc 11.3.0 and only icc raises this error.
You can for example see the error [here](https://gitlab.com/eT-program/eT/-/jobs/3696353086).

Let me know if I should update some changelog or something else, as well.