### PR TITLE
Gaussian nuclear model with fractional charges

### DIFF
--- a/include/cint.h.in
+++ b/include/cint.h.in
@@ -48,8 +48,8 @@
 #define CHARGE_OF       0
 #define PTR_COORD       1
 #define NUC_MOD_OF      2
-#define PTR_FRAC_CHARGE 3
-#define PTR_ZETA        4
+#define PTR_ZETA        3
+#define PTR_FRAC_CHARGE 4
 #define RESERVE_ATMLOT  5
 #define ATM_SLOTS       6
 

--- a/include/cint.h.in
+++ b/include/cint.h.in
@@ -48,10 +48,9 @@
 #define CHARGE_OF       0
 #define PTR_COORD       1
 #define NUC_MOD_OF      2
-#define PTR_ZETA        3
 #define PTR_FRAC_CHARGE 3
-#define RESERVE_ATMLOT1 4
-#define RESERVE_ATMLOT2 5
+#define PTR_ZETA        4
+#define RESERVE_ATMLOT  5
 #define ATM_SLOTS       6
 
 
@@ -131,6 +130,7 @@
 #define POINT_NUC       1
 #define GAUSSIAN_NUC    2
 #define FRAC_CHARGE_NUC 3
+#define FRAC_GAUSS_NUC  4
 
 #define bas(SLOT,I)     bas[BAS_SLOTS * (I) + (SLOT)]
 #define atm(SLOT,I)     atm[ATM_SLOTS * (I) + (SLOT)]

--- a/src/g1e.c
+++ b/src/g1e.c
@@ -191,7 +191,7 @@ double CINTnuc_mod(double aij, FINT nuc_id, FINT *atm, double *env)
         double zeta;
         if (nuc_id < 0) {
                 zeta = env[PTR_RINV_ZETA];
-        } else if ((atm(NUC_MOD_OF, nuc_id)-1) & 1 == 1) {
+        } else if ((atm(NUC_MOD_OF, nuc_id)-1) & (GAUSSIAN_NUC-1)) {
                 zeta = env[atm(PTR_ZETA, nuc_id)];
         } else {
                 zeta = 0;
@@ -225,7 +225,7 @@ FINT CINTg1e_nuc(double *g, CINTEnvVars *envs, FINT nuc_id)
         if (nuc_id < 0) {
                 fac1 = 2*M_PI * envs->fac[0] * tau / aij;
                 cr = env + PTR_RINV_ORIG;
-        } else if (((atm(NUC_MOD_OF, nuc_id)-1) & (1 << 1)) >> 1 == 1) {
+        } else if ((atm(NUC_MOD_OF, nuc_id)-1) & (FRAC_CHARGE_NUC-1)) {
                 fac1 = 2*M_PI * -env[atm[PTR_FRAC_CHARGE+nuc_id*ATM_SLOTS]] * envs->fac[0] * tau / aij;
                 cr = env + atm(PTR_COORD, nuc_id);
         } else {

--- a/src/g1e.c
+++ b/src/g1e.c
@@ -191,7 +191,7 @@ double CINTnuc_mod(double aij, FINT nuc_id, FINT *atm, double *env)
         double zeta;
         if (nuc_id < 0) {
                 zeta = env[PTR_RINV_ZETA];
-        } else if (atm(NUC_MOD_OF, nuc_id) == GAUSSIAN_NUC) {
+        } else if ((atm(NUC_MOD_OF, nuc_id)-1) & 1 == 1) {
                 zeta = env[atm(PTR_ZETA, nuc_id)];
         } else {
                 zeta = 0;
@@ -225,7 +225,7 @@ FINT CINTg1e_nuc(double *g, CINTEnvVars *envs, FINT nuc_id)
         if (nuc_id < 0) {
                 fac1 = 2*M_PI * envs->fac[0] * tau / aij;
                 cr = env + PTR_RINV_ORIG;
-        } else if (atm(NUC_MOD_OF, nuc_id) == FRAC_CHARGE_NUC) {
+        } else if (((atm(NUC_MOD_OF, nuc_id)-1) & (1 << 1)) >> 1 == 1) {
                 fac1 = 2*M_PI * -env[atm[PTR_FRAC_CHARGE+nuc_id*ATM_SLOTS]] * envs->fac[0] * tau / aij;
                 cr = env + atm(PTR_COORD, nuc_id);
         } else {


### PR DESCRIPTION
Possibility of using fractional charges with gaussian nuclear model at the same time (new NUC_MOD_OF). To choose between the different cases, a bitmask has been implemented using the last bit of `atm(NUC_MOD_OF, nuc_id)-1` from a given atom.
- Use zeta: for modes `GAUSSIAN_NUC` and `FRAC_GAUSS_NUC`.
- Use fractional charge: for modes `FRAC_CHARGE_NUC` and `FRAC_GAUSS_NUC`.
