### PR TITLE
Fixes for compilation errors on some compilers

### DIFF
--- a/src/fmt.c
+++ b/src/fmt.c
@@ -267,7 +267,7 @@ void lgamma_inc_like(long double *f, long double t, int m)
         }
 }
 
-inline double pow_(double base, int exponent)
+static inline double pow_(double base, int exponent)
 {
         int i;
         double result = 1;
@@ -280,7 +280,7 @@ inline double pow_(double base, int exponent)
         return result;
 }
 
-inline long double powl_(long double base, int exponent)
+static inline long double powl_(long double base, int exponent)
 {
         int i;
         long double result = 1.l;

--- a/src/fmt.c
+++ b/src/fmt.c
@@ -267,7 +267,7 @@ void lgamma_inc_like(long double *f, long double t, int m)
         }
 }
 
-inline double _pow(double base, int exponent)
+inline double pow_(double base, int exponent)
 {
         int i;
         double result = 1;
@@ -280,7 +280,7 @@ inline double _pow(double base, int exponent)
         return result;
 }
 
-inline long double _powl(long double base, int exponent)
+inline long double powl_(long double base, int exponent)
 {
         int i;
         long double result = 1.l;
@@ -315,7 +315,7 @@ void fmt1_erfc_like(double *f, double t, double lower, int m)
         double bi;
         double e = .5 * exp(-t);
         double e1 = .5 * exp(-t * lower2) * lower;
-        e1 *= _pow(lower2, m);
+        e1 *= pow_(lower2, m);
         double x = e;
         double x1 = e1;
         double s = e - e1;
@@ -427,7 +427,7 @@ void fmt1_lerfc_like(long double *f, long double t, long double lower, int m)
         long double bi;
         long double e = .5l * expl(-t);
         long double e1 = .5l * expl(-t * lower2) * lower;
-        e1 *= _powl(lower2, m);
+        e1 *= powl_(lower2, m);
         long double x = e;
         long double x1 = e1;
         long double s = e - e1;
@@ -493,7 +493,7 @@ void qgamma_inc_like(__float128 *f, __float128 t, int m)
         }
 }
 
-inline __float128 _powq(__float128 base, int exponent)
+inline __float128 powq_(__float128 base, int exponent)
 {
         int i;
         __float128 result = 1.q;
@@ -555,7 +555,7 @@ void fmt1_qerfc_like(__float128 *f, __float128 t, __float128 lower, int m)
         __float128 bi;
         __float128 e = .5q * expq(-t);
         __float128 e1 = .5q * expq(-t * lower2) * lower;
-        e1 *= _powq(lower2, m);
+        e1 *= powq_(lower2, m);
         __float128 x = e;
         __float128 x1 = e1;
         __float128 s = e - e1;

--- a/src/g1e.c
+++ b/src/g1e.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 #include "cint_bas.h"
 #include "misc.h"
 #include "g1e.h"


### PR DESCRIPTION
These changes are very minor, including:

The following:

  - Add missing `stdlib.h` include for `abs()` function in g1e.c
  - Change inline functions to static inline in `fmt.c` to fix linker errors
  - Adjust names of said inline functions to go from `_pow` to e.g. `pow_` to avoid possible issues with reserved names in c standard (should be ok a lot of the time, but could have fiddly compiler specific behaviour)

Hopefully these should be easy to squash and merge if you're happy with them!