### PR TITLE
Fix quadmath linking error

### DIFF
--- a/src/fmt.c
+++ b/src/fmt.c
@@ -493,7 +493,7 @@ void qgamma_inc_like(__float128 *f, __float128 t, int m)
         }
 }
 
-inline __float128 powq_(__float128 base, int exponent)
+static inline __float128 powq_(__float128 base, int exponent)
 {
         int i;
         __float128 result = 1.q;


### PR DESCRIPTION
I believe this is needed because as I understand it,
- when quadmath is found this function is defined

but 

- because it is not defined in `src/rys_roots.h`, then this won't have a symbol in the resulting shared library so I was getting a linking error

This matches `pow_` and `powl_` so I assume it is correct, but feel free to close if this is not needed.

This does fix the error with `gcc/10.2.0` (unfortunately the newest on this local dev machine that I was using. 

edit: similar to #120 
